### PR TITLE
Removes redundant "name" property from End events in Chrome trace

### DIFF
--- a/src/AnalysisExporter/BuildTimeline/BuildTimelineExporter.cpp
+++ b/src/AnalysisExporter/BuildTimeline/BuildTimelineExporter.cpp
@@ -109,7 +109,6 @@ void BuildTimelineExporter::AddEntry(const TimelineEntry* entry, rapidjson::Valu
             event.AddMember("ph", "E", document.GetAllocator());
             event.AddMember("pid", static_cast<uint64_t>(processId), document.GetAllocator());
             event.AddMember("tid", static_cast<uint64_t>(threadId), document.GetAllocator());
-            event.AddMember("name", entry->GetName(), document.GetAllocator());
             // time in microseconds
             event.AddMember("ts", std::chrono::duration_cast<std::chrono::microseconds>(entry->GetFinishTimestamp()).count(), document.GetAllocator());
 


### PR DESCRIPTION
They are supported in case you're streaming data and want to change the name you set in the Start event, but we've got all data upfront

Closes #15.