### PR TITLE
Unifies struct's member naming convention and initialization

### DIFF
--- a/src/AnalysisData/BuildTimeline/ProcessThreadRemapping/ProcessThreadRemapping.h
+++ b/src/AnalysisData/BuildTimeline/ProcessThreadRemapping/ProcessThreadRemapping.h
@@ -6,8 +6,8 @@
 
 struct ProcessThreadRemap
 {
-    TProcessId ProcessId;
-    TThreadId ThreadId;
+    TProcessId ProcessId = 0;
+    TThreadId ThreadId = 0;
 };
 
 typedef std::unordered_map<TEventInstanceId, ProcessThreadRemap> TProcessThreadRemappings;

--- a/src/AnalysisData/FileCompilationData.h
+++ b/src/AnalysisData/FileCompilationData.h
@@ -6,8 +6,8 @@ struct FileCompilationData
 {
     struct Pass
     {
-        std::chrono::nanoseconds Start;
-        std::chrono::nanoseconds Stop;
+        std::chrono::nanoseconds Start = std::chrono::nanoseconds(0);
+        std::chrono::nanoseconds Stop = std::chrono::nanoseconds(0);
     };
 
     Pass FrontEnd;

--- a/src/AnalysisData/TemplateInstantiationData.h
+++ b/src/AnalysisData/TemplateInstantiationData.h
@@ -8,9 +8,9 @@
 
 struct TemplateInstantiationData
 {
-    TSymbolKey Primary;
-    TSymbolKey Specialization;
-    std::chrono::nanoseconds Duration;
+    TSymbolKey Primary = 0;
+    TSymbolKey Specialization = 0;
+    std::chrono::nanoseconds Duration = std::chrono::nanoseconds(0);
 };
 
 typedef std::unordered_map<TEventInstanceId, TemplateInstantiationData> TTemplateInstantiationDataPerOccurrence;

--- a/src/AnalysisExporter/FileInclusions/FileInclusionTimesExporter.cpp
+++ b/src/AnalysisExporter/FileInclusions/FileInclusionTimesExporter.cpp
@@ -34,18 +34,21 @@ bool FileInclusionTimesExporter::ExportTo(const std::string& path) const
         std::chrono::nanoseconds totalTimeElapsed = averageTimeElapsed;
         averageTimeElapsed /= pair.second.size();
 
+        DataPerFile data;
+        data.FilePath = &pair.first;
+        data.TotalInclusionTime = totalTimeElapsed;
+        data.AverageInclusionTime = averageTimeElapsed;
+        data.Occurrences = static_cast<unsigned int>(pair.second.size());
+
         // store data
-        dataPerFile.emplace_back(&pair.first,
-                                 totalTimeElapsed,
-                                 averageTimeElapsed,
-                                 static_cast<unsigned int>(pair.second.size()));
+        dataPerFile.emplace_back(data);
     }
 
     // sort entries
     std::sort(dataPerFile.begin(), dataPerFile.end(), [](const DataPerFile& lhs, const DataPerFile& rhs)
     {
         // slowest inclusions first
-        return lhs.totalInclusionTime > rhs.totalInclusionTime;
+        return lhs.TotalInclusionTime > rhs.TotalInclusionTime;
     });
 
     // write data header to stream
@@ -57,10 +60,10 @@ bool FileInclusionTimesExporter::ExportTo(const std::string& path) const
     // write data to stream
     for (auto&& data : dataPerFile)
     {
-        out << (*data.filePath) << ";"
-            << data.totalInclusionTime.count() << ";"
-            << data.averageInclusionTime.count() << ";"
-            << data.occurrences << std::endl;
+        out << (*data.FilePath) << ";"
+            << data.TotalInclusionTime.count() << ";"
+            << data.AverageInclusionTime.count() << ";"
+            << data.Occurrences << std::endl;
     }
 
     out.close();

--- a/src/AnalysisExporter/FileInclusions/FileInclusionTimesExporter.h
+++ b/src/AnalysisExporter/FileInclusions/FileInclusionTimesExporter.h
@@ -18,21 +18,10 @@ private:
     // to be exported
     struct DataPerFile
     {
-        const std::string* filePath;
-        std::chrono::nanoseconds totalInclusionTime;
-        std::chrono::nanoseconds averageInclusionTime;
-        unsigned int occurrences;
-
-        DataPerFile(const std::string* filePath,
-                    const std::chrono::nanoseconds& totalInclusionTime,
-                    const std::chrono::nanoseconds& averageInclusionTime,
-                    unsigned int occurrences)
-            : filePath(filePath)
-            , totalInclusionTime(totalInclusionTime)
-            , averageInclusionTime(averageInclusionTime)
-            , occurrences(occurrences)
-        {
-        }
+        const std::string* FilePath = nullptr;
+        std::chrono::nanoseconds TotalInclusionTime = std::chrono::nanoseconds(0);
+        std::chrono::nanoseconds AverageInclusionTime = std::chrono::nanoseconds(0);
+        unsigned int Occurrences = 0;
     };
 
     const TTimeElapsedPerOccurrencePerConcept& m_data;

--- a/src/AnalysisExporter/FunctionCompilations/FunctionCompilationsExporter.cpp
+++ b/src/AnalysisExporter/FunctionCompilations/FunctionCompilationsExporter.cpp
@@ -37,18 +37,21 @@ bool FunctionCompilationsExporter::ExportTo(const std::string& path) const
         const std::chrono::nanoseconds totalTimeElapsed = averageTimeElapsed;
         averageTimeElapsed /= pair.second.size();
 
+        DataPerFunction data;
+        data.FunctionName = &pair.first;
+        data.TotalCompilationTime = totalTimeElapsed;
+        data.AverageCompilationTime = averageTimeElapsed;
+        data.Occurrences = static_cast<unsigned int>(pair.second.size());
+
         // store data
-        dataPerFunction.emplace_back(&pair.first,
-                                     totalTimeElapsed,
-                                     averageTimeElapsed,
-                                     static_cast<unsigned int>(pair.second.size()));
+        dataPerFunction.emplace_back(data);
     }
 
     // sort entries
     std::sort(dataPerFunction.begin(), dataPerFunction.end(), [](const DataPerFunction& lhs, const DataPerFunction& rhs)
     {
         // slowest functions first
-        return lhs.averageCompilationTime > rhs.averageCompilationTime;
+        return lhs.AverageCompilationTime > rhs.AverageCompilationTime;
     });
 
     // write data header to stream
@@ -62,11 +65,11 @@ bool FunctionCompilationsExporter::ExportTo(const std::string& path) const
     for (auto&& data : dataPerFunction)
     {
         // dump to stream
-        out << (*data.functionName) << ";"
-            << Utilities::CppBuildInsightsDataConversion::UndecorateFunction(*data.functionName) << ";"
-            << data.totalCompilationTime.count() << ";"
-            << data.averageCompilationTime.count() << ";"
-            << data.occurrences << std::endl;
+        out << (*data.FunctionName) << ";"
+            << Utilities::CppBuildInsightsDataConversion::UndecorateFunction(*data.FunctionName) << ";"
+            << data.TotalCompilationTime.count() << ";"
+            << data.AverageCompilationTime.count() << ";"
+            << data.Occurrences << std::endl;
     }
 
     out.close();

--- a/src/AnalysisExporter/FunctionCompilations/FunctionCompilationsExporter.h
+++ b/src/AnalysisExporter/FunctionCompilations/FunctionCompilationsExporter.h
@@ -18,21 +18,10 @@ private:
     // to be exported
     struct DataPerFunction
     {
-        const std::string* functionName;
-        std::chrono::nanoseconds totalCompilationTime;
-        std::chrono::nanoseconds averageCompilationTime;
-        unsigned int occurrences;
-
-        DataPerFunction(const std::string* functionName,
-                        const std::chrono::nanoseconds& totalCompilationTime,
-                        const std::chrono::nanoseconds& averageCompilationTime,
-                        unsigned int occurrences)
-            : functionName(functionName)
-            , totalCompilationTime(totalCompilationTime)
-            , averageCompilationTime(averageCompilationTime)
-            , occurrences(occurrences)
-        {
-        }
+        const std::string* FunctionName = nullptr;
+        std::chrono::nanoseconds TotalCompilationTime = std::chrono::nanoseconds(0);
+        std::chrono::nanoseconds AverageCompilationTime = std::chrono::nanoseconds(0);
+        unsigned int Occurrences = 0;
     };
 
     const TTimeElapsedPerOccurrencePerConcept& m_data;

--- a/src/AnalysisExporter/TemplateInstantiations/TemplateInstantiationsExporter.cpp
+++ b/src/AnalysisExporter/TemplateInstantiations/TemplateInstantiationsExporter.cpp
@@ -39,11 +39,11 @@ bool TemplateInstantiationsExporter::ExportTo(const std::string& path) const
             auto itPrimaryTemplateName = m_symbolNames.find(pair.second.Primary);
             assert(itPrimaryTemplateName != m_symbolNames.end());
 
-            result.first->second.primaryTemplateKey = &itPrimaryTemplateName->second;
+            result.first->second.PrimaryTemplateKey = &itPrimaryTemplateName->second;
         }
 
-        result.first->second.occurrences.push_back(pair.second.Duration);
-        result.first->second.totalInstantiationTime += pair.second.Duration;
+        result.first->second.Occurrences.push_back(pair.second.Duration);
+        result.first->second.TotalInstantiationTime += pair.second.Duration;
     }
 
     // sort
@@ -57,7 +57,7 @@ bool TemplateInstantiationsExporter::ExportTo(const std::string& path) const
     std::sort(sortedAggregatedData.begin(), sortedAggregatedData.end(), [](const TAggregatedData::value_type* lhs,
                                                                            const TAggregatedData::value_type* rhs)
     {
-        return lhs->second.totalInstantiationTime > rhs->second.totalInstantiationTime;
+        return lhs->second.TotalInstantiationTime > rhs->second.TotalInstantiationTime;
     });
 
     // write data header to stream
@@ -71,10 +71,10 @@ bool TemplateInstantiationsExporter::ExportTo(const std::string& path) const
     for (auto&& data : sortedAggregatedData)
     {
         out << data->first << ";"
-            << *data->second.primaryTemplateKey << ";"
-            << data->second.totalInstantiationTime.count() << ";"
-            << (data->second.totalInstantiationTime / data->second.occurrences.size()).count() << ";"
-            << data->second.occurrences.size() << std::endl;
+            << *data->second.PrimaryTemplateKey << ";"
+            << data->second.TotalInstantiationTime.count() << ";"
+            << (data->second.TotalInstantiationTime / data->second.Occurrences.size()).count() << ";"
+            << data->second.Occurrences.size() << std::endl;
     }
 
     out.close();

--- a/src/AnalysisExporter/TemplateInstantiations/TemplateInstantiationsExporter.h
+++ b/src/AnalysisExporter/TemplateInstantiations/TemplateInstantiationsExporter.h
@@ -18,9 +18,9 @@ public:
 private:
     struct DataPerTemplate
     {
-        const std::string* primaryTemplateKey;
-        std::chrono::nanoseconds totalInstantiationTime;
-        std::vector<std::chrono::nanoseconds> occurrences;
+        const std::string* PrimaryTemplateKey = nullptr;
+        std::chrono::nanoseconds TotalInstantiationTime = std::chrono::nanoseconds(0);
+        std::vector<std::chrono::nanoseconds> Occurrences;
     };
 
     const TSymbolNames& m_symbolNames;

--- a/src/BuildAnalyzer/BuildAnalyzer.cpp
+++ b/src/BuildAnalyzer/BuildAnalyzer.cpp
@@ -24,7 +24,7 @@ BuildAnalyzer::BuildAnalyzer(const std::string& traceFilePath, const AnalysisOpt
     , m_fileInclusions()
     , m_fileCompilations()
     , m_buildTimeline()
-    , m_filterTimeline(analysisOptions.timelineIgnoreFunctionsUnder, analysisOptions.timelineIgnoreTemplatesUnder)
+    , m_filterTimeline(analysisOptions.TimelineIgnoreFunctionsUnder, analysisOptions.TimelineIgnoreTemplatesUnder)
     , m_analysisPerformed(false)
     , m_templateInstantiations()
 {
@@ -56,28 +56,28 @@ std::vector<CppBI::IAnalyzer*> BuildAnalyzer::BuildAnalyzerList(const AnalysisOp
 {
     std::vector<CppBI::IAnalyzer*> analyzers;
 
-    if (options.functionCompilations)
+    if (options.FunctionCompilations)
     {
         analyzers.push_back(&m_functionCompilations);
     }
 
-    if (options.fileInclusionTimes || options.fileInclusionGraph)
+    if (options.FileInclusionTimes || options.FileInclusionGraph)
     {
         analyzers.push_back(&m_fileInclusions);
     }
 
-    if (options.fileCompilations)
+    if (options.FileCompilations)
     {
         analyzers.push_back(&m_fileCompilations);
     }
 
-    if (options.buildTimeline)
+    if (options.BuildTimeline)
     {
         analyzers.push_back(&m_buildTimeline);
         analyzers.push_back(&m_filterTimeline);
     }
 
-    if (options.templateInstantiations)
+    if (options.TemplateInstantiations)
     {
         analyzers.push_back(&m_templateInstantiations);
     }

--- a/src/BuildAnalyzer/BuildAnalyzer.h
+++ b/src/BuildAnalyzer/BuildAnalyzer.h
@@ -20,14 +20,14 @@ class BuildAnalyzer
 public:
     struct AnalysisOptions
     {
-        std::chrono::milliseconds timelineIgnoreFunctionsUnder = std::chrono::milliseconds(0);
-        std::chrono::milliseconds timelineIgnoreTemplatesUnder = std::chrono::milliseconds(0);
-        bool functionCompilations = true;
-        bool fileInclusionTimes = true;
-        bool fileInclusionGraph = true;
-        bool fileCompilations = true;
-        bool buildTimeline = true;
-        bool templateInstantiations = true;
+        std::chrono::milliseconds TimelineIgnoreFunctionsUnder = std::chrono::milliseconds(0);
+        std::chrono::milliseconds TimelineIgnoreTemplatesUnder = std::chrono::milliseconds(0);
+        bool FunctionCompilations = true;
+        bool FileInclusionTimes = true;
+        bool FileInclusionGraph = true;
+        bool FileCompilations = true;
+        bool BuildTimeline = true;
+        bool TemplateInstantiations = true;
     };
 
 public:

--- a/src/ConsoleMain/Main.cpp
+++ b/src/ConsoleMain/Main.cpp
@@ -95,14 +95,14 @@ int main(int argc, char** argv)
 
     // what to build
     BuildAnalyzer::AnalysisOptions analysisOptions;
-    analysisOptions.functionCompilations = analyzeAll || analyzeFunctionCompilations;
-    analysisOptions.fileInclusionTimes = analyzeAll || analyzeFileInclusionTimes;
-    analysisOptions.fileInclusionGraph = analyzeAll || createFileInclusionGraph;
-    analysisOptions.fileCompilations = analyzeAll || analyzeFileCompilations;
-    analysisOptions.buildTimeline = analyzeAll || createBuildTimeline;
-    analysisOptions.templateInstantiations = analyzeAll || analyzeTemplateInstantiations;
-    analysisOptions.timelineIgnoreFunctionsUnder = std::chrono::milliseconds(timelineIgnoreFunctionsUnderMs);
-    analysisOptions.timelineIgnoreTemplatesUnder = std::chrono::milliseconds(timelineIgnoreTemplatesUnderMs);
+    analysisOptions.FunctionCompilations = analyzeAll || analyzeFunctionCompilations;
+    analysisOptions.FileInclusionTimes = analyzeAll || analyzeFileInclusionTimes;
+    analysisOptions.FileInclusionGraph = analyzeAll || createFileInclusionGraph;
+    analysisOptions.FileCompilations = analyzeAll || analyzeFileCompilations;
+    analysisOptions.BuildTimeline = analyzeAll || createBuildTimeline;
+    analysisOptions.TemplateInstantiations = analyzeAll || analyzeTemplateInstantiations;
+    analysisOptions.TimelineIgnoreFunctionsUnder = std::chrono::milliseconds(timelineIgnoreFunctionsUnderMs);
+    analysisOptions.TimelineIgnoreTemplatesUnder = std::chrono::milliseconds(timelineIgnoreTemplatesUnderMs);
 
     // analyze trace
     std::cout << "Analyzing..." << std::endl;
@@ -112,7 +112,7 @@ int main(int argc, char** argv)
     // export data
     if (succeeded)
     {
-        if (analysisOptions.functionCompilations)
+        if (analysisOptions.FunctionCompilations)
         {
             std::cout << "Exporting function compilations..." << std::endl;
             
@@ -126,7 +126,7 @@ int main(int argc, char** argv)
             }
         }
 
-        if (analysisOptions.fileInclusionTimes)
+        if (analysisOptions.FileInclusionTimes)
         {
             std::cout << "Exporting file inclusion times..." << std::endl;
 
@@ -140,7 +140,7 @@ int main(int argc, char** argv)
             }
         }
         
-        if (analysisOptions.fileInclusionGraph)
+        if (analysisOptions.FileInclusionGraph)
         {
             std::cout << "Exporting file inclusion graph..." << std::endl;
 
@@ -154,7 +154,7 @@ int main(int argc, char** argv)
             }
         }
         
-        if (analysisOptions.fileCompilations)
+        if (analysisOptions.FileCompilations)
         {
             std::cout << "Exporting file compilations..." << std::endl;
 
@@ -168,7 +168,7 @@ int main(int argc, char** argv)
             }
         }
         
-        if (analysisOptions.buildTimeline)
+        if (analysisOptions.BuildTimeline)
         {
             std::cout << "Exporting build timeline..." << std::endl;
             
@@ -182,7 +182,7 @@ int main(int argc, char** argv)
             }
         }
 
-        if (analysisOptions.templateInstantiations)
+        if (analysisOptions.TemplateInstantiations)
         {
             std::cout << "Exporting template instantiations..." << std::endl;
 


### PR DESCRIPTION
Decides the following convention:

Members use `UpperCamelCase` and get initialized in the definitions.
They don't define a constructor (so they can't be used within an `emplace` method), probably want to consider this for future revisions.

Resolves #27.