### PR TITLE
Renames Thread activities by prepending parent activity name

### DIFF
--- a/src/BuildAnalyzer/Analyzers/BuildTimeline/BuildTimelineAnalyzer.cpp
+++ b/src/BuildAnalyzer/Analyzers/BuildTimeline/BuildTimelineAnalyzer.cpp
@@ -27,7 +27,8 @@ CppBI::AnalysisControl BuildTimelineAnalyzer::OnStartActivity(const CppBI::Event
         CppBI::MatchEventInMemberFunction(eventStack.Back(), this, &BuildTimelineAnalyzer::OnInvocation) ||
         CppBI::MatchEventInMemberFunction(eventStack.Back(), this, &BuildTimelineAnalyzer::OnFrontEndFile) ||
         CppBI::MatchEventInMemberFunction(eventStack.Back(), this, &BuildTimelineAnalyzer::OnFunction) ||
-        CppBI::MatchEventStackInMemberFunction(eventStack,   this, &BuildTimelineAnalyzer::OnTemplateInstantiation);
+        CppBI::MatchEventStackInMemberFunction(eventStack,   this, &BuildTimelineAnalyzer::OnTemplateInstantiation) ||
+        CppBI::MatchEventStackInMemberFunction(eventStack,   this, &BuildTimelineAnalyzer::OnThread);
 
     return CppBI::AnalysisControl::CONTINUE;
 }
@@ -111,6 +112,11 @@ void BuildTimelineAnalyzer::OnTemplateInstantiation(const CppBI::Activities::Tem
     auto result = m_unresolvedTemplateInstantiationsPerSymbol.try_emplace(templateInstantiation.SpecializationSymbolKey(),
                                                                             TUnresolvedTemplateInstantiations());
     result.first->second.push_back(templateInstantiation.EventInstanceId());
+}
+
+void BuildTimelineAnalyzer::OnThread(const CppBI::Activities::Activity& parent, const CppBI::Activities::Thread& thread)
+{
+    m_buildTimeline.UpdateEntryName(thread.EventInstanceId(), std::string(parent.EventName()) + std::string(thread.EventName()));
 }
 
 // ----------------------------------------------------------------------------

--- a/src/BuildAnalyzer/Analyzers/BuildTimeline/BuildTimelineAnalyzer.h
+++ b/src/BuildAnalyzer/Analyzers/BuildTimeline/BuildTimelineAnalyzer.h
@@ -39,6 +39,7 @@ private:
     void OnFrontEndFile(const CppBI::Activities::FrontEndFile& frontEndFile);
     void OnFunction(const CppBI::Activities::Function& function);
     void OnTemplateInstantiation(const CppBI::Activities::TemplateInstantiation& templateInstantiation);
+    void OnThread(const CppBI::Activities::Activity& parent, const CppBI::Activities::Thread& thread);
 
     // specific event handling
     void OnSymbolNameEvent(const CppBI::SimpleEvents::SymbolName& event);


### PR DESCRIPTION
Based on my contribution in https://github.com/microsoft/vcperf/pull/8/commits/834303f0493be0988b2cabbb0c029e882fa9617f.