### PR TITLE
! seems vs2019 output path can be null as well

### DIFF
--- a/src/BuildAnalyzer/Analyzers/FileCompilations/FileCompilationsAnalyzer.cpp
+++ b/src/BuildAnalyzer/Analyzers/FileCompilations/FileCompilationsAnalyzer.cpp
@@ -48,6 +48,12 @@ const wchar_t* FileCompilationsAnalyzer::GetFilePath(const CppBI::Activities::Co
         return compilerPass.InputSourcePath();
     }
 
-    assert(compilerPass.OutputObjectPath() != nullptr);
-    return compilerPass.OutputObjectPath();
+    // ms turns out VS2019 OutputObjectPath can be null too
+    // fallback on something
+    if (compilerPass.OutputObjectPath() != nullptr)
+    {
+        return compilerPass.OutputObjectPath();
+    }
+
+    return L"Unknown";
 }


### PR DESCRIPTION
not sure why it's null 
not sure what to do with this but at least it doesn't crash  🤷 